### PR TITLE
2.0 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Return a data type from a string representing the data type.
 Mostly useful for using with [ndarray](https://github.com/mikolalysenko/ndarray)
 where you would like instantiate a typed array of the same `array.dtype`.
 
+See [ndarray-dtype](https://www.npmjs.com/package/ndarray-dtype) if you need to support Buffer and other ndarray types.
+
 ## example
 
 ```js
@@ -33,12 +35,8 @@ Data type | String
 `Float64Array` | "float64"
 `Array` | "array"
 `Uint8ClampedArray` | "uint8_clamped"
-`ArrayBuffer` | "generic"
-`ArrayBuffer` | "data"
-`ArrayBuffer` | "dataview"
-`Buffer` | "buffer"
 
-> If `Buffer` is not present then `"buffer"` will return `ArrayBuffer`.
+Returns `undefined` if the type isn't recognized.
 
 ## install
 
@@ -50,7 +48,12 @@ npm install dtype
 
 Use [browserify](http://browserify.org) to `require('dtype')`.
 
+## see also
+
+- [ndarray-dtype](https://www.npmjs.com/package/ndarray-dtype)
+
 ## release history
+* 2.0.0 - moving buffer, generic and data to a different module
 * 1.0.0 - Add uint8_clamped, generic, data, dataview and buffer types
 * 0.1.0 - initial release
 

--- a/index.js
+++ b/index.js
@@ -20,12 +20,5 @@ module.exports = function(dtype) {
       return Array
     case 'uint8_clamped':
       return Uint8ClampedArray
-    case 'generic':
-    case 'data':
-    case 'dataview':
-      return ArrayBuffer
-    case 'buffer':
-      if (typeof Buffer === "undefined") return ArrayBuffer
-      return Buffer
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,12 +15,7 @@
   "bugs": {
     "url": "https://github.com/shama/dtype/issues"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/shama/dtype/blob/master/LICENSE-MIT"
-    }
-  ],
+  "license": "MIT",
   "engines": {
     "node": ">= 0.8.0"
   },

--- a/test.js
+++ b/test.js
@@ -23,6 +23,5 @@ test('dtype', function(t) {
   t.ok(arr instanceof Array)
   arr = new (dtype('uint8_clamped'))
   t.ok(arr instanceof Uint8ClampedArray)
-  arr = new (dtype('buffer'))(0)
-  t.ok(arr instanceof Buffer)
+  t.equal(dtype('buffer'), undefined, 'returns undefined for non-array types')
 })


### PR DESCRIPTION
- reverted this module to be a bit more like it was in 1.x (with uint8_clamped though)
- added notes on `ndarray-dtype`
- you'll notice [ndarray-dtype](https://github.com/mattdesl/ndarray-dtype) just returns undefined if Buffer doesn't exist globally, I figure this leads to less surprise and doesn't force the dev to use [is-buffer](https://www.npmjs.com/package/is-buffer) on the return value
- update `license` field since `liceses` is deprecated/non-standard

:tada: :birthday: 
